### PR TITLE
other platforms have more than just fedora

### DIFF
--- a/count_ood_users.rb
+++ b/count_ood_users.rb
@@ -19,7 +19,7 @@ def load_etc_release
 end
 
 def log_dir
-  if ENV['ID_LIKE'].to_s == 'fedora'
+  if ENV['ID_LIKE'].to_s =~ /.*fedora.*/
     if ENV['VERSION_ID'].to_s < '8.0'
       '/var/log/httpd24'
     else
@@ -31,7 +31,7 @@ def log_dir
 end
 
 def etc_dir
-  if ENV['ID_LIKE'].to_s == 'fedora'
+  if ENV['ID_LIKE'].to_s =~ /.*fedora.*/
     if ENV['VERSION_ID'].to_s < '8.0'
       '/opt/rh/httpd24/root/etc/httpd'
     else

--- a/count_ood_users.sh
+++ b/count_ood_users.sh
@@ -2,7 +2,7 @@
 
 source /etc/os-release
 
-if [[ "$ID_LIKE" == "fedora" ]]; then
+if [[ "$ID_LIKE" =~ "fedora" ]]; then
   if [[ "$VERSION_ID" < "8.0" ]]; then
     HTTPD_DIR="/var/log/httpd24"
     ETC_DIR="/opt/rh/httpd24/root/etc/httpd"


### PR DESCRIPTION
other platforms have more than just fedora

so this needs to account for 
```
ID_LIKE='rhel centos fedora'
```

this on Rocky and 
```
ID_LIKE='fedora'
```
this on RHEL.